### PR TITLE
fix: preserve specific purchase validation errors

### DIFF
--- a/src/app/api/purchase/route.ts
+++ b/src/app/api/purchase/route.ts
@@ -4,7 +4,7 @@ import { nanoid } from "nanoid";
 import { FlightLib__factory, FlightOracle__factory, FlightProduct__factory, FlightUSD__factory } from "../../../contracts/flight";
 import { IPolicyService__factory } from "../../../contracts/gif";
 import { IBundleService__factory, IPoolService__factory } from "../../../contracts/gif/factories/pool";
-import { AirportBlacklistedError, AirportNotWhitelistedError, TransactionFailedException } from "../../../types/errors";
+import { AirportBlacklistedError, AirportNotWhitelistedError, FlightNotFoundError, InconsistentFlightDataError, TransactionFailedException } from "../../../types/errors";
 import { Airport } from "../../../types/flightstats/airport";
 import { ApplicationData, PermitData, PurchaseRequest } from "../../../types/purchase_request";
 import { LOGGER } from "../../../utils/logger_backend";
@@ -52,6 +52,16 @@ export async function POST(request: Request) {
         } else if (err instanceof AirportNotWhitelistedError) {
             return Response.json({
                 error: "AIRPORT_NOT_WHITELISTED",
+                message: err.message,
+            }, { status: 400 });
+        } else if (err instanceof FlightNotFoundError) {
+            return Response.json({
+                error: "NO_FLIGHT_FOUND",
+                message: err.message,
+            }, { status: 404 });
+        } else if (err instanceof InconsistentFlightDataError) {
+            return Response.json({
+                error: "INCONSISTENT_DATA",
                 message: err.message,
             }, { status: 400 });
         } else {
@@ -141,7 +151,7 @@ async function validateFlightPlan(reqId: string, application: ApplicationData) {
     } catch (err) {
         // @ts-expect-error error has field message
         LOGGER.error(err.message);
-        throw new Error(`[${reqId}] Flight not found`);
+        throw new FlightNotFoundError(`[${reqId}] Flight not found`);
     }
 }
 
@@ -157,13 +167,13 @@ async function validateStatistics(reqId: string, application: ApplicationData) {
     const fsResponse = await fetch(url);
 
     if (!fsResponse.ok) {
-        throw new Error(`[${reqId}] Flight not found on flightstats api`);
+        throw new FlightNotFoundError(`[${reqId}] Flight not found on flightstats api`);
     }
 
     const fsData = await fsResponse.json();
 
     if (fsData.ratings === undefined || fsData.ratings.length === 0) {
-        throw new Error(`[${reqId}] Flight ratings not found`);
+        throw new FlightNotFoundError(`[${reqId}] Flight ratings not found`);
     }
 
     const rating = fsData.ratings[0] as Rating;
@@ -172,12 +182,12 @@ async function validateStatistics(reqId: string, application: ApplicationData) {
 
     // compare stats vs application statistics
     if (stats.length !== application.statistics.length) {
-        throw new Error(`[${reqId}] Statistics length mismatch`);
+        throw new InconsistentFlightDataError(`[${reqId}] Statistics length mismatch`);
     }
 
     LOGGER.debug(`stats: ${JSON.stringify(stats)}, application statistics: ${JSON.stringify(application.statistics)}`);
     if (!stats.every((value, index) => value === application.statistics[index])) {
-        throw new Error(`[${reqId}] Statistics mismatch`);
+        throw new InconsistentFlightDataError(`[${reqId}] Statistics mismatch`);
     }
 }
 

--- a/src/hooks/api/use_local_api.tsx
+++ b/src/hooks/api/use_local_api.tsx
@@ -1,5 +1,6 @@
+import { PurchaseErrorCode } from "../../types/errors";
 import { ApplicationData, PermitData } from "../../types/purchase_request";
-import { PurchaseFailedError, PurchaseNotPossibleError } from "../../utils/error";
+import { PurchaseFailedError, PurchaseNotPossibleError, PurchaseValidationError } from "../../utils/error";
 
 // @ts-expect-error BigInt is not defined in the global scope
 BigInt.prototype.toJSON = function () {
@@ -29,8 +30,10 @@ export function useLocalApi() {
                 throw new PurchaseFailedError(result.transaction, result.decodedError);
             } else if (result.error === "BALANCE_ERROR") {
                 throw new PurchaseNotPossibleError();
+            } else if (Object.values(PurchaseErrorCode).includes(result.error as PurchaseErrorCode)) {
+                throw new PurchaseValidationError(result.error as PurchaseErrorCode);
             } else {
-                throw new Error(`Error sending purchase protection request: ${result.statusText}`);
+                throw new Error(result.message || `Error sending purchase protection request: ${res.statusText}`);
             }   
         } 
 

--- a/src/hooks/use_application.tsx
+++ b/src/hooks/use_application.tsx
@@ -8,7 +8,8 @@ import { resetPurchase, setExecuting, setPolicy, setSigning } from "../redux/sli
 import { RootState } from "../redux/store";
 import { Erc20PermitSignature } from "../types/erc20permitsignature";
 import { ApplicationData, PermitData } from "../types/purchase_request";
-import { PurchaseFailedError, PurchaseNotPossibleError } from "../utils/error";
+import { PurchaseErrorCode } from "../types/errors";
+import { PurchaseFailedError, PurchaseNotPossibleError, PurchaseValidationError } from "../utils/error";
 import { useLocalApi } from "./api/use_local_api";
 import { useERC20Contract } from "./onchain/use_erc20_contract";
 import { useFlightDelayProductContract } from "./onchain/use_flightdelay_product";
@@ -167,6 +168,22 @@ export default function useApplication() {
                 dispatch(setError({ message: `${t("error.purchase_failed")} (${err.decodedError?.reason || "unknown error"})`, level: "error" }));
             } else if (err instanceof PurchaseNotPossibleError) {
                 dispatch(setError({ message: t("error.purchase_currently_not_possible"), level: "error" }));
+            } else if (err instanceof PurchaseValidationError) {
+                switch (err.code) {
+                    case PurchaseErrorCode.NO_FLIGHT_FOUND:
+                        dispatch(setError({ message: t("error.no_flight_found"), level: "error" }));
+                        break;
+                    case PurchaseErrorCode.INCONSISTENT_DATA:
+                        dispatch(setError({ message: t("error.inconsistent_data"), level: "error" }));
+                        break;
+                    case PurchaseErrorCode.AIRPORT_BLACKLISTED:
+                    case PurchaseErrorCode.AIRPORT_NOT_WHITELISTED:
+                        dispatch(setError({ message: t("error.purchase_currently_not_possible"), level: "error" }));
+                        break;
+                    default:
+                        dispatch(setError({ message: t("error.unknown_error"), level: "error" }));
+                        break;
+                }
             } else {
                 // @ts-expect-error code is custom field for metamask error
                 if (err.code !== undefined) {

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -9,6 +9,25 @@ export enum Reason {
     NOT_ENOUGH_CAPACITY,
 }
 
+export enum PurchaseErrorCode {
+    NO_FLIGHT_FOUND = "NO_FLIGHT_FOUND",
+    INCONSISTENT_DATA = "INCONSISTENT_DATA",
+    AIRPORT_BLACKLISTED = "AIRPORT_BLACKLISTED",
+    AIRPORT_NOT_WHITELISTED = "AIRPORT_NOT_WHITELISTED",
+}
+
+export class FlightNotFoundError extends Error {
+    constructor(message = 'Flight not found') {
+        super(message);
+    }
+}
+
+export class InconsistentFlightDataError extends Error {
+    constructor(message = 'Inconsistent flight data') {
+        super(message);
+    }
+}
+
 /**
  * Exception thrown when a transaction fails. Contains the transaction receipt in field `transaction`.
  */

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,4 +1,5 @@
 import { DecodedError } from "ethers-decode-error";
+import { PurchaseErrorCode } from "../types/errors";
 
 export function ensureError(value: unknown): Error {
     if (value instanceof Error) return value;
@@ -48,6 +49,15 @@ export class PurchaseFailedError extends Error {
 export class PurchaseNotPossibleError extends Error {
     constructor() {
         super("Purchase not possible");
+    }
+}
+
+export class PurchaseValidationError extends Error {
+    code: PurchaseErrorCode;
+
+    constructor(code: PurchaseErrorCode) {
+        super(`Purchase validation failed: ${code}`);
+        this.code = code;
     }
 }
 


### PR DESCRIPTION
## Summary
- preserve structured purchase-validation failures from the API route to the client
- surface `No matching flight found` and inconsistent flight-data errors instead of collapsing them into generic purchase failures
- keep the change narrowly scoped to the purchase error path

## Root cause
The purchase API already distinguished a few backend failures (`TX_FAILED`, balance, airport checks), but flight-validation failures during purchase could still fall through as generic unexpected errors. The client adapter then collapsed unrecognized API failures into a generic `Error`, which caused the UI to lose specific user-facing messages.

## What changed
- added typed purchase-validation error codes/classes for the purchase flow
- returned explicit API errors for:
  - `NO_FLIGHT_FOUND`
  - `INCONSISTENT_DATA`
- mapped those errors in `use_local_api.tsx` to a typed client-side validation error
- updated `use_application.tsx` to render the correct translated message instead of a generic unknown/purchase failure

## Validation
- `npm install`
- `npm run lint`
- `npm run build`

Fixes #275
