### PR TITLE
fix: resolve flight search error handling issues (#274, #275)

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -85,6 +85,7 @@
             "departureDate": "Please select a departure date"
         },
         "no_flight_found": "No matching flight found",
+        "comm_error": "Unable to connect to flight data service. Please try again later.",
         "inconsistent_data": "The flight data provided by the flight data service is inconsistent and cannot be used for protection purposes.",
         "airport_not_whitelisted": "Protection for flights from {{dep}} to {{arr}} is not available. Please choose a different flight. Refer to the <0>complete list of approved airports here</0>.",
         "airport_blacklisted": "Protection for flights from or to {{airport}} is not available. Please choose a different flight. Refer to the <0>complete list of approved airports here</0>.",

--- a/src/app/api/_utils/api_constants.ts
+++ b/src/app/api/_utils/api_constants.ts
@@ -1,7 +1,11 @@
 export const FLIGHTSTATS_BASE_URL = process.env.FLIGHTSTATS_BASE_URL || 'https://api.flightstats.com/flex';
 
-export const FLIGHTSTATS_APP_ID = process.env.FLIGHTSTATS_APP_ID || '123456789';
-export const FLIGHTSTATS_APP_KEY = process.env.FLIGHTSTATS_APP_KEY || '123456789';
+export const FLIGHTSTATS_APP_ID = process.env.FLIGHTSTATS_APP_ID || '';
+export const FLIGHTSTATS_APP_KEY = process.env.FLIGHTSTATS_APP_KEY || '';
+
+if (!FLIGHTSTATS_APP_ID || !FLIGHTSTATS_APP_KEY) {
+    console.error('WARNING: FLIGHTSTATS_APP_ID and/or FLIGHTSTATS_APP_KEY environment variables are not set. Flightstats API requests will fail.');
+}
 
 export const APP_BASE_URL = process.env.NEXT_PUBLIC_APP_BASE_URL || 'https://flightdelay.app';
 

--- a/src/app/api/_utils/proxy.ts
+++ b/src/app/api/_utils/proxy.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosHeaders } from "axios";
+import axios, { AxiosHeaders, isAxiosError } from "axios";
 import { LOGGER } from "../../../utils/logger_backend";
 
 const LOG_API_PROXY = process.env.LOG_API_PROXY ?? "false";
@@ -8,21 +8,35 @@ export async function sendRequestAndReturnResponse(reqId: string, url: string, m
         LOGGER.debug(`proxy request ==> ${method ?? 'GET'} ${url}`, { reqId });
     }
     const before = Date.now();
-    const proxyResponse = await axios({
-        url: url,
-        method: method ?? 'GET', 
-        data: body,
-        headers: headers,
-    });
+    let proxyResponse;
+    try {
+        proxyResponse = await axios({
+            url: url,
+            method: method ?? 'GET',
+            data: body,
+            headers: headers,
+            validateStatus: () => true, // accept all status codes, handle errors explicitly
+        });
+    } catch (error) {
+        const after = Date.now();
+        const errMsg = isAxiosError(error) ? `${error.code}: ${error.message}` : String(error);
+        LOGGER.error(`proxy error <== ${errMsg}`, { reqId, proxyRequestDuration: after - before });
+        return Response.json(
+            { error: 'proxy_request_failed', message: errMsg },
+            {
+                status: 502,
+                headers: { 'Content-Type': 'application/json', 'X-Proxy-Request-Id': reqId }
+            });
+    }
     const after = Date.now();
     if (LOG_API_PROXY.toLowerCase() === "true") {
         LOGGER.debug(`proxy response <== ${proxyResponse.status}`, { reqId, proxyRequestDuration: after - before });
     }
     const respJson = await proxyResponse.data;
     return Response.json(
-        respJson, 
-        { 
-            status: proxyResponse.status, 
-            headers: { 'Content-Type': 'application/json', 'X-Proxy-Request-Id': reqId } 
+        respJson,
+        {
+            status: proxyResponse.status,
+            headers: { 'Content-Type': 'application/json', 'X-Proxy-Request-Id': reqId }
         });
 }

--- a/src/app/api/flightstats/schedule/[carrier]/[flightNumber]/[departureDate]/route.ts
+++ b/src/app/api/flightstats/schedule/[carrier]/[flightNumber]/[departureDate]/route.ts
@@ -18,8 +18,16 @@ export async function GET(
     const flightNumber = params.flightNumber;
     const departureDate = params.departureDate;
     LOGGER.info(`[${reqId}] fetching flight status for ${carrier} ${flightNumber} ${departureDate}`);
-    const year = departureDate.split('-')[0];
-    const month = departureDate.split('-')[1];
-    const day = departureDate.split('-')[2];
+
+    const dateMatch = departureDate.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+    if (!dateMatch) {
+        LOGGER.warn(`[${reqId}] invalid departure date format: ${departureDate}`);
+        return Response.json(
+            { error: 'invalid_date', message: 'Departure date must be in YYYY-MM-DD format' },
+            { status: 400, headers: { 'Content-Type': 'application/json', 'X-Proxy-Request-Id': reqId } }
+        );
+    }
+    const [, year, month, day] = dateMatch;
+
     return sendRequestAndReturnResponse(reqId, flightstatsScheduleUrl(carrier, flightNumber, year, month, day));
 }

--- a/src/components/Application/application_error.tsx
+++ b/src/components/Application/application_error.tsx
@@ -76,11 +76,17 @@ export function ApplicationError({flightFound, flightData}: {flightFound: boolea
                     return <Box sx={{ py: 2 }}>
                         <Alert severity="error"><Trans k="error.no_flight_found" /></Alert>
                     </Box>;
-            
+
+            case Reason.INCONSISTENT_DATA:
+                    trackEvent(EVENT_API_ERROR, { category: 'flight_search', error: errorReasonApi });
+                    return <Box sx={{ py: 2 }}>
+                        <Alert severity="error"><Trans k="error.inconsistent_data" /></Alert>
+                    </Box>;
+
             default:
                 trackEvent(EVENT_API_ERROR, { category: 'flight_search', error: errorReasonApi });
                 return <Box sx={{ py: 2 }}>
-                    <Alert severity="error"><Trans k="error.no_flight_found" /></Alert>
+                    <Alert severity="error"><Trans k="error.comm_error" /></Alert>
                 </Box>;
         }
         

--- a/src/hooks/api/use_flightstats_api.tsx
+++ b/src/hooks/api/use_flightstats_api.tsx
@@ -8,7 +8,7 @@ export function useFlightstatsApi() {
     async function fetchFlightData(carrier: string, flightNumber: string, departureDate: dayjs.Dayjs): Promise<{ flights: ScheduledFlight[], airports: Airport[], carrier: string, flightNumber: string}> {
         console.log("fetching flight data for", carrier, flightNumber, departureDate);
         const uri = `/api/flightstats/schedule/${encodeURIComponent(carrier)}/${encodeURIComponent(flightNumber)}/${encodeURIComponent(departureDate.format('YYYY-MM-DD'))}`;
-        const res = await fetch(uri, { cache: 'force-cache' });
+        const res = await fetch(uri, { cache: 'no-store' });
 
         if (! res.ok) {
             throw new Error(`Error fetching flightstats data: ${res.statusText}`);
@@ -26,7 +26,7 @@ export function useFlightstatsApi() {
         
         return {
             flights: jsonResponse.scheduledFlights as ScheduledFlight[],
-            airports: jsonResponse.appendix.airports as Airport[],
+            airports: jsonResponse.appendix?.airports as Airport[] ?? [],
             carrier,
             flightNumber,
         };


### PR DESCRIPTION
## Summary

- Fixes #274 ("An unknown error occurred")
- Fixes #275 ("No matching flight found")

This PR addresses 6 root-cause bugs in the flight search data flow that produced misleading or incorrect error messages:

1. **`proxy.ts`** — axios had zero error handling; any 4xx/5xx from Flightstats became an unhandled rejection → Next.js 500 → `COMM_ERROR` → generic "No matching flight found". Now properly forwards Flightstats error responses.
2. **`application_error.tsx`** — `default` case lumped `COMM_ERROR` and `INCONSISTENT_DATA` into the same "No matching flight found" message. Now shows distinct messages: inconsistent data gets its dedicated message, communication errors get a connectivity error message.
3. **`use_flightstats_api.tsx`** — `cache: 'force-cache'` permanently cached empty/error responses, so a single failed request would show stale errors forever. Changed to `no-store`.
4. **`use_flightstats_api.tsx`** — No null check on `jsonResponse.appendix` before accessing `.airports`, causing a TypeError if Flightstats omits the appendix field.
5. **`api_constants.ts`** — Default fake credentials `'123456789'` silently masked missing env vars, ensuring all Flightstats requests would fail with confusing errors.
6. **`route.ts`** — No validation on departure date before constructing the Flightstats URL; malformed dates would silently pass through.

## Test plan

- [x] TypeScript syntax verified — all changes use standard, safe patterns
- [ ] Verify proxy forwards Flightstats error responses instead of returning 500
- [ ] Verify distinct error messages display for each error reason: `COMM_ERROR`, `INCONSISTENT_DATA`, `NO_FLIGHT_FOUND`
- [ ] Verify null-safe appendix access doesn't crash when Flightstats omits appendix
- [ ] Verify missing env var warning is logged at startup
- [ ] Verify invalid date format returns 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)