### PR TITLE
Fix: No matching flight found issue (#275)

### DIFF
--- a/src/components/Application/application_error.tsx
+++ b/src/components/Application/application_error.tsx
@@ -80,7 +80,7 @@ export function ApplicationError({flightFound, flightData}: {flightFound: boolea
             default:
                 trackEvent(EVENT_API_ERROR, { category: 'flight_search', error: errorReasonApi });
                 return <Box sx={{ py: 2 }}>
-                    <Alert severity="error"><Trans k="error.no_flight_found" /></Alert>
+                    <Alert severity="error"><Trans k="error.unknown_error" /></Alert>
                 </Box>;
         }
         


### PR DESCRIPTION
Closes #275. Fixes the bug where an unknown API error would fall back to the incorrect translation key 'error.no_flight_found' instead of 'error.unknown_error'.